### PR TITLE
Fix: Correctly use output folders specified by -o argument.

### DIFF
--- a/src/tngsdk/package/packager.py
+++ b/src/tngsdk/package/packager.py
@@ -893,11 +893,14 @@ class TangoPackager(EtsiPackager):
             # 8. generate/write TOSCA
             self._pack_gen_write_tosca_manifest(napdr, napd_path, etsi_mf_path)
             # 9. zip package
+            auto_file_name = "{}.{}.{}.tgo".format(napdr.vendor,
+                                                   napdr.name,
+                                                   napdr.version)
             path_dest = self.args.output
             if path_dest is None:
-                path_dest = "{}.{}.{}.tgo".format(napdr.vendor,
-                                                  napdr.name,
-                                                  napdr.version)
+                path_dest = auto_file_name
+            if os.path.isdir(path_dest):
+                path_dest = os.path.join(path_dest, auto_file_name)
             creat_zip_file_from_directory(napdr._project_wd, path_dest)
             LOG.info("Package created: '{}'"
                      .format(path_dest))

--- a/src/tngsdk/package/tests/test_unit_cli.py
+++ b/src/tngsdk/package/tests/test_unit_cli.py
@@ -67,8 +67,9 @@ class TngSdkPackageCliTest(unittest.TestCase):
         self.assertIsNotNone(r.error)
         shutil.rmtree(tempdir)
 
-    def test_cli_package(self):
+    def test_cli_package_fixed_name(self):
         tempdir = tempfile.mkdtemp()
+        # specify a fixed name for the output
         pkg_path = os.path.join(tempdir, "package.tgo")
         args = cli.parse_args(
             ["-p", "misc/5gtango_ns_project_example1/",
@@ -77,3 +78,15 @@ class TngSdkPackageCliTest(unittest.TestCase):
         self.assertIsNone(r.error)
         self.assertTrue(os.path.exists(pkg_path))
         shutil.rmtree(tempdir)
+
+    def test_cli_package_auto_name(self):
+        # specify output dir. but not file name
+        pkg_path = tempfile.mkdtemp()
+        args = cli.parse_args(
+            ["-p", "misc/5gtango_ns_project_example1/",
+             "-o", pkg_path])
+        r = cli.dispatch(args)
+        self.assertIsNone(r.error)
+        self.assertTrue(
+            os.path.exists(pkg_path))
+        shutil.rmtree(pkg_path)


### PR DESCRIPTION
Closes #102

Signed-off-by: peusterm <manuel.peuster@uni-paderborn.de>