### PR TITLE
CLI argument and REST interface argument for the validation level

### DIFF
--- a/src/tngsdk/package/cli.py
+++ b/src/tngsdk/package/cli.py
@@ -224,6 +224,14 @@ def parse_args(input_args=None):
         dest="skip_validation",
         action="store_true")
 
+    parser.add_argument(
+        "--validation_level",
+        help="Set validation level. Possible values: 's' or 'syntax', 'i' or 'integrity', 't' or 'topology' , 'skip'",
+        choices=['s', 'syntax', 'i', 'integrity', 't', 'topology', 'skip'],
+        required=False,
+        default='t',
+        dest="validation_level")
+
     # only needed for validator
     parser.add_argument(
         "-w", "--workspace",

--- a/src/tngsdk/package/cli.py
+++ b/src/tngsdk/package/cli.py
@@ -226,7 +226,8 @@ def parse_args(input_args=None):
 
     parser.add_argument(
         "--validation_level",
-        help="Set validation level. Possible values: 's' or 'syntax', 'i' or 'integrity', 't' or 'topology' , 'skip'",
+        help="""Set validation level. Possible values: 's' or 'syntax',
+         'i' or 'integrity', 't' or 'topology' , 'skip'""",
         choices=['s', 'syntax', 'i', 'integrity', 't', 'topology', 'skip'],
         required=False,
         default='t',

--- a/src/tngsdk/package/packager.py
+++ b/src/tngsdk/package/packager.py
@@ -873,7 +873,6 @@ class TangoPackager(EtsiPackager):
                 tmp_napdr = tmp_tpfbe.store(
                     napdr, wd, self.args.unpackage, output=tmp_project_path)
                 tmp_project_path = tmp_napdr.metadata["_storage_location"]
-                print("\n" + "-"*20 + "\n" + "test:" + str(self.args) + "\n" + "-"*20 + "\n")
                 validate_project_with_external_validator(
                     self.args, tmp_project_path)
                 shutil.rmtree(tmp_project_path)
@@ -911,11 +910,10 @@ class TangoPackager(EtsiPackager):
                  .format(project_path))
         try:
             # 0. validate project with external validator
-            if self.args.skip_validation:
+            if self.args.skip_validation or self.args.validation_level == "skip":
                 LOG.warning(
                     "Skipping validation (--skip-validation).")
             else:
-                print("test argument: ", self.args)
                 validate_project_with_external_validator(
                     self.args, project_path)
             # 1. find and load project descriptor

--- a/src/tngsdk/package/packager.py
+++ b/src/tngsdk/package/packager.py
@@ -864,7 +864,7 @@ class TangoPackager(EtsiPackager):
             # always use the 5GTANGO project storage backend:
             # Solution: we store it to a temporary 5GTANGO project
             # only used for the validation step.
-            if self.args.skip_validation:
+            if self.args.skip_validation or self.args.validation_level == 'skip':
                 LOG.warning(
                     "Skipping validation (--skip-validation).")
             else:  # ok, do the validation
@@ -873,6 +873,7 @@ class TangoPackager(EtsiPackager):
                 tmp_napdr = tmp_tpfbe.store(
                     napdr, wd, self.args.unpackage, output=tmp_project_path)
                 tmp_project_path = tmp_napdr.metadata["_storage_location"]
+                print("\n" + "-"*20 + "\n" + "test:" + str(self.args) + "\n" + "-"*20 + "\n")
                 validate_project_with_external_validator(
                     self.args, tmp_project_path)
                 shutil.rmtree(tmp_project_path)
@@ -914,6 +915,7 @@ class TangoPackager(EtsiPackager):
                 LOG.warning(
                     "Skipping validation (--skip-validation).")
             else:
+                print("test argument: ", self.args)
                 validate_project_with_external_validator(
                     self.args, project_path)
             # 1. find and load project descriptor

--- a/src/tngsdk/package/packager.py
+++ b/src/tngsdk/package/packager.py
@@ -864,7 +864,8 @@ class TangoPackager(EtsiPackager):
             # always use the 5GTANGO project storage backend:
             # Solution: we store it to a temporary 5GTANGO project
             # only used for the validation step.
-            if self.args.skip_validation or self.args.validation_level == 'skip':
+            if (self.args.skip_validation or
+                self.args.validation_level == 'skip'):
                 LOG.warning(
                     "Skipping validation (--skip-validation).")
             else:  # ok, do the validation
@@ -910,7 +911,8 @@ class TangoPackager(EtsiPackager):
                  .format(project_path))
         try:
             # 0. validate project with external validator
-            if self.args.skip_validation or self.args.validation_level == "skip":
+            if (self.args.skip_validation or
+                self.args.validation_level == "skip"):
                 LOG.warning(
                     "Skipping validation (--skip-validation).")
             else:

--- a/src/tngsdk/package/packager.py
+++ b/src/tngsdk/package/packager.py
@@ -865,7 +865,7 @@ class TangoPackager(EtsiPackager):
             # Solution: we store it to a temporary 5GTANGO project
             # only used for the validation step.
             if (self.args.skip_validation or
-                self.args.validation_level == 'skip'):
+                    self.args.validation_level == 'skip'):
                 LOG.warning(
                     "Skipping validation (--skip-validation).")
             else:  # ok, do the validation
@@ -912,7 +912,7 @@ class TangoPackager(EtsiPackager):
         try:
             # 0. validate project with external validator
             if (self.args.skip_validation or
-                self.args.validation_level == "skip"):
+                    self.args.validation_level == "skip"):
                 LOG.warning(
                     "Skipping validation (--skip-validation).")
             else:

--- a/src/tngsdk/package/rest.py
+++ b/src/tngsdk/package/rest.py
@@ -122,6 +122,13 @@ packages_parser.add_argument("skip_validation",
                              required=False,
                              default=False,
                              help="Skip service validation (optional)")
+packages_parser.add_argument("validation_level",
+                             location="form",
+                             type=str,
+                             choices=['s', 'syntax', 'i', 'integrity', 't', 'topology', 'skip'],
+                             required=False,
+                             default='t',
+                             help="Set validation level. Possible values: 's' or 'syntax', 'i' or 'integrity', 't' or 'topology' , 'skip'")
 packages_parser.add_argument("workspace",
                              location="form",
                              help="Workspace (ignored for now)")

--- a/src/tngsdk/package/rest.py
+++ b/src/tngsdk/package/rest.py
@@ -125,10 +125,13 @@ packages_parser.add_argument("skip_validation",
 packages_parser.add_argument("validation_level",
                              location="form",
                              type=str,
-                             choices=['s', 'syntax', 'i', 'integrity', 't', 'topology', 'skip'],
+                             choices=['s', 'syntax', 'i', 'integrity',
+                                      't', 'topology', 'skip'],
                              required=False,
                              default='t',
-                             help="Set validation level. Possible values: 's' or 'syntax', 'i' or 'integrity', 't' or 'topology' , 'skip'")
+                             help="""Set validation level.
+                              Possible values: 's' or 'syntax',
+                               'i' or 'integrity', 't' or 'topology' , 'skip'""")
 packages_parser.add_argument("workspace",
                              location="form",
                              help="Workspace (ignored for now)")

--- a/src/tngsdk/package/rest.py
+++ b/src/tngsdk/package/rest.py
@@ -130,8 +130,11 @@ packages_parser.add_argument("validation_level",
                              required=False,
                              default='t',
                              help="""Set validation level.
-                              Possible values: 's' or 'syntax',
-                               'i' or 'integrity', 't' or 'topology' , 'skip'""")
+                              Possible values:
+                               's' or 'syntax',
+                               'i' or 'integrity',
+                               't' or 'topology' ,
+                               'skip'""")
 packages_parser.add_argument("workspace",
                              location="form",
                              help="Workspace (ignored for now)")

--- a/src/tngsdk/package/validator.py
+++ b/src/tngsdk/package/validator.py
@@ -58,7 +58,7 @@ def validate_project_with_external_validator(args, project_path):
         return
     # ok! let us valiade ...
     v = Validator()
-    # define validation_level 
+    # define validation_level
     if len(args.validation_level) == 1:
         validation_level = "-"+args.validation_level
     else:

--- a/src/tngsdk/package/validator.py
+++ b/src/tngsdk/package/validator.py
@@ -58,9 +58,14 @@ def validate_project_with_external_validator(args, project_path):
         return
     # ok! let us valiade ...
     v = Validator()
+    # define validation_level 
+    if len(args.validation_level) == 1:
+        validation_level = "-"+args.validation_level
+    else:
+        validation_level = "--"+args.validation_level
     # define arguments for validator
     v_args = v_cli.parse_args([
-        "-t",  # levels -s / -i / -t
+        validation_level,  # levels -s / -i / -t
         "--debug",  # temporary
         "--project", project_path,  # path to project
         "--workspace", args.workspace  # workspace path


### PR DESCRIPTION
Changes in cli.py, packager.py, rest.py, validator.py:

cli.py and rest.py: one more add_argument instruction for the parser
validator.py: adjusted with new argument
packager.py: case: --validation_level.py skip

https://github.com/sonata-nfv/tng-sdk-package/issues/159#issue-433593823